### PR TITLE
Fix dateparser Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Date parser for eventDates, eventStartDates, eventEndDates in [AtoM](https://acc
 
 ## Installation
 
-Install with pip form [PyPi](https://pypi.org/project/atomdateparser/):
+Install with pip from [PyPi](https://pypi.org/project/atomdateparser/):
 
 ```
 pip install atomdateparser

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file_handle:
 
 setup(
     name='atomdateparser',
-    version='0.0.1',
+    version='0.0.2',
     author='Daniel Lovegrove',
     author_email='d.lovegrove11@gmail.com',
     description='Parse eventDates for AtoM CSVs',
@@ -19,5 +19,10 @@ setup(
     install_requires=[
         "dateparser>=1.0.0",
     ],
+    extras_require={
+        'dev': [
+            'pytest'
+        ]
+    },
     python_requires='>=3.6',
 )

--- a/src/atomdateparser/handlers.py
+++ b/src/atomdateparser/handlers.py
@@ -682,7 +682,7 @@ class DateParserHandler(BaseDateHandler):
 
     def __init__(self, unknown_date, unknown_start_date, unknown_end_date, **kwargs):
         super().__init__(unknown_date, unknown_start_date, unknown_end_date)
-        self.dateparser_kwargs = kwargs
+        self.dateparser_kwargs = kwargs.get('dateparser_kwargs') or {}
 
     def handle(self, date: str):
         ''' dateparser.parse is slow when the date is in an unrecognizable

--- a/src/atomdateparser/test/test_parser.py
+++ b/src/atomdateparser/test/test_parser.py
@@ -2,6 +2,7 @@ import pytest
 
 from atomdateparser.parser import EventDateParser
 
+
 class TestParseDatesNoStartOrEndDates_IgnoreEventActors:
     @pytest.mark.parametrize('event_dates', [
         ('n.d.'),
@@ -121,6 +122,19 @@ class TestParseDatesNoStartOrEndDates_IgnoreEventActors:
         assert parsed['eventDates'] == expected_event_dates
         assert parsed['eventStartDates'] == expected_early
         assert parsed['eventEndDates'] == expected_late
+
+    def test_handle_with_dateparser(self):
+        parser = EventDateParser(dateparser_kwargs={
+            'settings': {
+                'PREFER_DAY_OF_MONTH': 'last',
+            },
+            'languages': ['fr'],
+        })
+        parsed = parser.parse_event_dates('août 1995')
+        assert parsed['eventDates'] == '1995-08-31'
+        assert parsed['eventStartDates'] == '1995-08-31'
+        assert parsed['eventEndDates'] == '1995-08-31'
+
 
 class TestParseWithStartEndDatesPresent_IgnoreEventActors:
     @pytest.mark.parametrize('event_dates,event_start_dates,event_end_dates,expected', [


### PR DESCRIPTION
Fixes issue where dateparser kwargs are not passed correctly to `dateparser.parse()`.